### PR TITLE
Provide grey placeholder for text fields on login screen

### DIFF
--- a/Cookivan/Controller/LoginVC.swift
+++ b/Cookivan/Controller/LoginVC.swift
@@ -19,7 +19,7 @@ class LoginVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationView()
-
+        setupTextFields()
         // Do any additional setup after loading the view.
     }
 
@@ -75,4 +75,25 @@ class LoginVC: UIViewController {
     func setupNavigationView() {
         navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
     }
+}
+
+// MARK: - Private methods
+
+extension LoginVC {
+
+    private func setupTextFields() {
+        let placeholderAttributes = [NSAttributedString.Key.foregroundColor: UIColor.gray]
+        let emailTextFieldPlaceholderString =
+            NSLocalizedString("email", comment: "Placeholder text for email field on login screen")
+        let emailTextFieldPlaceholder =
+            NSAttributedString(string: emailTextFieldPlaceholderString, attributes: placeholderAttributes)
+        self.emailTxtField.attributedPlaceholder = emailTextFieldPlaceholder
+
+        let passwordTextFieldPlaceholderString =
+            NSLocalizedString("password", comment: "Placeholder text for password field on login screen")
+        let passwordTextFieldPlaceholder =
+            NSAttributedString(string: passwordTextFieldPlaceholderString, attributes: placeholderAttributes)
+        self.passwordTxtField.attributedPlaceholder = passwordTextFieldPlaceholder
+    }
+
 }

--- a/Cookivan/Controller/RegistrationVC.swift
+++ b/Cookivan/Controller/RegistrationVC.swift
@@ -26,7 +26,7 @@ class RegistrationVC: UIViewController {
         super.viewDidLoad()
         backBarButtonItemSetup()
         checkItemSwitch()
-
+        setupTextFields()
     }
 
     func checkItemSwitch() {
@@ -104,4 +104,39 @@ class RegistrationVC: UIViewController {
 //            self.activityIndicator.stopAnimating()
 //        }
 //    }
+}
+
+// MARK: - Private methods
+
+extension RegistrationVC {
+
+    private func setupTextFields() {
+        let placeholderAttributes = [NSAttributedString.Key.foregroundColor: UIColor.gray]
+        let usernameTextFieldPlaceholderString =
+            NSLocalizedString("username", comment: "Placeholder text for username field on registration screen")
+        let usernameTextFieldPlaceholder =
+            NSAttributedString(string: usernameTextFieldPlaceholderString, attributes: placeholderAttributes)
+        self.usernameTxt.attributedPlaceholder = usernameTextFieldPlaceholder
+
+        let emailTextFieldPlaceholderString =
+            NSLocalizedString("email", comment: "Placeholder text for email field on registration screen")
+        let emailTextFieldPlaceholder =
+            NSAttributedString(string: emailTextFieldPlaceholderString, attributes: placeholderAttributes)
+        self.emailTxt.attributedPlaceholder = emailTextFieldPlaceholder
+
+        let passwordTextFieldPlaceholderString =
+            NSLocalizedString("password", comment: "Placeholder text for password field on registration screen")
+        let passwordTextFieldPlaceholder =
+            NSAttributedString(string: passwordTextFieldPlaceholderString, attributes: placeholderAttributes)
+        self.passwordTxt.attributedPlaceholder = passwordTextFieldPlaceholder
+
+        let confirmPassTextFieldPlaceholderString =
+            NSLocalizedString("confirm password",
+                              comment: "Placeholder text for confirm pass field on registration screen")
+        let confirmPasswordTextFieldPlaceholder =
+            NSAttributedString(string: confirmPassTextFieldPlaceholderString, attributes: placeholderAttributes)
+        self.confirmPassTxt.attributedPlaceholder = confirmPasswordTextFieldPlaceholder
+
+    }
+
 }


### PR DESCRIPTION
**Ticket:** https://trello.com/c/KKpauyl3
**Issue:** Standart placeholder colors do not match with a current background image.
**Description:** Only text can be changed for UITextField placeholder. For more customization NSAttributedString can be used for setting specific attributes to a placeholder. For both fields placeholder set grey color as text color