### PR TITLE
Code style proposals

### DIFF
--- a/Cookivan.xcodeproj/project.pbxproj
+++ b/Cookivan.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 		5856371322E081260034EBF1 /* ForgotPasswordVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5856371122E081260034EBF1 /* ForgotPasswordVC.swift */; };
 		5856371422E081260034EBF1 /* ForgotPasswordVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5856371222E081260034EBF1 /* ForgotPasswordVC.xib */; };
 		587A505922DB14610010781F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587A505822DB14610010781F /* AppDelegate.swift */; };
-		587A505B22DB14610010781F /* LoginVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587A505A22DB14610010781F /* LoginVC.swift */; };
+		587A505B22DB14610010781F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587A505A22DB14610010781F /* LoginViewController.swift */; };
 		587A505E22DB14610010781F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 587A505C22DB14610010781F /* Main.storyboard */; };
 		587A506022DB14620010781F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 587A505F22DB14620010781F /* Assets.xcassets */; };
 		587A506322DB14620010781F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 587A506122DB14620010781F /* LaunchScreen.storyboard */; };
@@ -94,7 +94,7 @@
 		5856371222E081260034EBF1 /* ForgotPasswordVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ForgotPasswordVC.xib; sourceTree = "<group>"; };
 		587A505522DB14600010781F /* Cookivan.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cookivan.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		587A505822DB14610010781F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		587A505A22DB14610010781F /* LoginVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVC.swift; sourceTree = "<group>"; };
+		587A505A22DB14610010781F /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		587A505D22DB14610010781F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		587A505F22DB14620010781F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		587A506222DB14620010781F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -251,7 +251,7 @@
 		587A508822DB14AD0010781F /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				587A505A22DB14610010781F /* LoginVC.swift */,
+				587A505A22DB14610010781F /* LoginViewController.swift */,
 				58CF756422DC79A600729617 /* RegistrationVC.swift */,
 				5856371122E081260034EBF1 /* ForgotPasswordVC.swift */,
 				584FFD5A22EECEF400A7CB0F /* MainRecipesVC.swift */,
@@ -565,7 +565,7 @@
 				58CF756C22DCA19300729617 /* RoundedViews.swift in Sources */,
 				584FFD7A22F035AF00A7CB0F /* PlainTableViewCell.swift in Sources */,
 				581E2FDA2301B1A20065EDAB /* SubCategoryVC.swift in Sources */,
-				587A505B22DB14610010781F /* LoginVC.swift in Sources */,
+				587A505B22DB14610010781F /* LoginViewController.swift in Sources */,
 				58176BF22309C66200F2D7C0 /* TestVC.swift in Sources */,
 				584FFD7722EF21F000A7CB0F /* MainRecipesVC.swift in Sources */,
 				09BFAF0D235134910034FB1D /* RecipesCollectionViewCell.swift in Sources */,

--- a/Cookivan/Controller/LoginViewController.swift
+++ b/Cookivan/Controller/LoginViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  LoginViewController.swift
 //  Cookivan
 //
 //  Created by Angelina on 7/14/19.
@@ -10,31 +10,30 @@ import UIKit
 import Firebase
 import FirebaseAuth
 
-class LoginVC: UIViewController {
+class LoginViewController: UIViewController {
 
-    @IBOutlet weak var emailTxtField: RoundedTextField!
-    @IBOutlet weak var passwordTxtField: RoundedTextField!
+    @IBOutlet weak var emailTextField: RoundedTextField!
+    @IBOutlet weak var passwordTextField: RoundedTextField!
     @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationView()
         setupTextFields()
-        // Do any additional setup after loading the view.
     }
 
-    @IBAction func forgotPassClicked(_ sender: Any) {
+    @IBAction func forgotPassClicked(_ sender: UIButton) {
         let viewController = ForgotPasswordVC()
         viewController.modalTransitionStyle = .crossDissolve
         viewController.modalPresentationStyle = .overCurrentContext
         present(viewController, animated: true, completion: nil)
     }
 
-    @IBAction func loginClicked(_ sender: Any) {
+    @IBAction func loginClicked(_ sender: UIButton) {
         userSignin()
     }
 
-    @IBAction func guestClicked(_ sender: Any) {
+    @IBAction func guestClicked(_ sender: UIButton) {
 //        dismiss(animated: true, completion: nil)
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let viewController = storyboard.instantiateViewController(withIdentifier: "TabBarControllerSID")
@@ -44,8 +43,8 @@ class LoginVC: UIViewController {
     }
 
     func userSignin() {
-        guard let email = emailTxtField.text, email.isNotEmpty,
-              let password = passwordTxtField.text, password.isNotEmpty else {
+        guard let email = self.emailTextField.text, email.isNotEmpty,
+              let password = self.passwordTextField.text, password.isNotEmpty else {
             simpleAlert(title: "Пожалуйста, заполните все поля.", msg: "")
             return
         }
@@ -58,7 +57,7 @@ class LoginVC: UIViewController {
 //            }
 //            self.dismiss(animated: true, completion: nil)
 //        }
-        activityIndicator.startAnimating()
+        self.activityIndicator.startAnimating()
         FireBaseStorage().signIn(withEmail: email, password: password) { result in
             self.activityIndicator.stopAnimating()
             do {
@@ -79,7 +78,7 @@ class LoginVC: UIViewController {
 
 // MARK: - Private methods
 
-extension LoginVC {
+extension LoginViewController {
 
     private func setupTextFields() {
         let placeholderAttributes = [NSAttributedString.Key.foregroundColor: UIColor.gray]
@@ -87,13 +86,13 @@ extension LoginVC {
             NSLocalizedString("email", comment: "Placeholder text for email field on login screen")
         let emailTextFieldPlaceholder =
             NSAttributedString(string: emailTextFieldPlaceholderString, attributes: placeholderAttributes)
-        self.emailTxtField.attributedPlaceholder = emailTextFieldPlaceholder
+        self.emailTextField.attributedPlaceholder = emailTextFieldPlaceholder
 
         let passwordTextFieldPlaceholderString =
             NSLocalizedString("password", comment: "Placeholder text for password field on login screen")
         let passwordTextFieldPlaceholder =
             NSAttributedString(string: passwordTextFieldPlaceholderString, attributes: placeholderAttributes)
-        self.passwordTxtField.attributedPlaceholder = passwordTextFieldPlaceholder
+        self.passwordTextField.attributedPlaceholder = passwordTextFieldPlaceholder
     }
 
 }

--- a/Cookivan/Storyboards/Base.lproj/Main.storyboard
+++ b/Cookivan/Storyboards/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,10 +16,10 @@
         </array>
     </customFonts>
     <scenes>
-        <!--LoginVC-->
+        <!--Login View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="LoginVC" customModule="Cookivan" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="LoginViewController" customModule="Cookivan" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -168,8 +168,8 @@
                     <navigationItem key="navigationItem" id="H3g-gE-3Jh"/>
                     <connections>
                         <outlet property="activityIndicator" destination="c2b-Cv-EQJ" id="jTU-hg-fsN"/>
-                        <outlet property="emailTxtField" destination="Cqv-L8-hho" id="aBx-n6-LKS"/>
-                        <outlet property="passwordTxtField" destination="sw6-Ai-kgI" id="JGX-zu-IR0"/>
+                        <outlet property="emailTextField" destination="Cqv-L8-hho" id="aBx-n6-LKS"/>
+                        <outlet property="passwordTextField" destination="sw6-Ai-kgI" id="JGX-zu-IR0"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
1. Renamed LoginVC to LoginViewController. In general, it is recommended to not use short names for classes, members, properties, etc.
2. Renamed `txtField`s to `textFields`, the reason for rename is the same
3. Used `self` for class properties. In most of the swift commercial projects is a common way to specify members of classes by specifying `self` before the member name.
4. Remove unused comments in code

Feel free to discuss any of those changes before merge.

In case you want to merge it. please do not merge it before 2 previous PRs